### PR TITLE
Fix for dev purrr

### DIFF
--- a/R/FUNCTIONS.R
+++ b/R/FUNCTIONS.R
@@ -1336,7 +1336,8 @@ descriptives <-
       purrr::map_depth(
         .depth = 3,
         descriptives_component,
-        na_string = na_string
+        na_string = na_string,
+        .ragged = TRUE
       ) %>%
       
       #Bind columns


### PR DESCRIPTION
map_depth() now errors (as documented) if the list isn't as deep as you expect. I've made the minimal change to keep the code working as before.